### PR TITLE
remove unnecessary encoding

### DIFF
--- a/LIVESTREAM.js
+++ b/LIVESTREAM.js
@@ -17,6 +17,8 @@ rl.question('Enter the RTMP link and Stream KEY: ', (rtmpLink) => {
         .audioCodec('copy')
         .outputOptions([
         '-preset', 'veryfast',
+        '-r', '30',
+        '-b:v' '2000k',
         '-f', 'flv',
         '-flvflags', 'no_duration_filesize',
         '-stimeout', '-1',

--- a/LIVESTREAM.js
+++ b/LIVESTREAM.js
@@ -10,19 +10,14 @@ rl.question('Enter the RTMP link and Stream KEY: ', (rtmpLink) => {
   rl.question('Enter Video Name: ', (inputVideo) => {
       ffmpeg()
         .input(inputVideo)
-        .inputOptions(['-stream_loop -1'])
-        .videoCodec('libx264')
-        .audioCodec('aac')
+        .inputOptions(['-re', 
+                       '-stream_loop -1',
+                      ])
+        .videoCodec('copy')
+        .audioCodec('copy')
         .outputOptions([
-        '-preset', 'slow',
-        '-crf', '23',
-        '-pix_fmt', 'yuv420p',
-        '-profile:v', 'main',
-        '-level', '4.1',
-        '-b:v', '2500k',
-        '-r', '30',
-        '-g', '60',
-        '-b:a', '128k',
-        '-ac', '2',
-        '-ar', '44100',
+        '-preset', 'veryfast',
+        '-f', 'flv',
+        '-flvflags', 'no_duration_filesize',
+        '-stimeout', '-1',
       ])

--- a/LIVESTREAM.js
+++ b/LIVESTREAM.js
@@ -11,7 +11,7 @@ rl.question('Enter the RTMP link and Stream KEY: ', (rtmpLink) => {
       ffmpeg()
         .input(inputVideo)
         .inputOptions(['-re', 
-                       '-stream_loop -1',
+                       '-stream_loop -1'
                       ])
         .videoCodec('copy')
         .audioCodec('copy')


### PR DESCRIPTION
It's pointless to encode video that doesn't need to be encoded, since most of the live/video recorder already encode the video to x264 and AAC audio, therefore encoding it again with the same encoding option is a waste of resources.

(-re) is enough for the stream to be going not too fast (going native), since it will encode (or in this case copy the stream) per frame.

Advantage:
Less resource usage (CPU/GPU usage)
More friendly to low-spec setup (don't know how low, though)

Disadvantage:
The video file that want to be streamed needed to be encoded in x264 and AAC audio (which was standard for most of the video files anyway)

Example usage: not even 1% CPU was used
![zcx](https://github.com/fr00t16/shipilivitiiils/assets/57262344/24fc4659-b8a2-488e-92cc-846ad01b16f1)
